### PR TITLE
Add efficacy monitoring

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ppseq
 Title: Design Clinical Trials using Sequential Predictive Probability Monitoring
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: 
   c(person(given = "Emily C.",
           family = "Zabor",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ppseq
 Title: Design Clinical Trials using Sequential Predictive Probability Monitoring
-Version: 0.1.2
+Version: 0.1.2.9000
 Authors@R: 
   c(person(given = "Emily C.",
           family = "Zabor",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# ppseq (development version)
+
 # ppseq 0.1.2
 
 # ppseq 0.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 # ppseq (development version)
 
+* Added the option for efficacy monitoring in `calibrate_thresholds()`, default is still futility monitoring
+
 # ppseq 0.1.2
+
+* Updating all examples to run without \donttest{} 
+* Some minor documentation changes
 
 # ppseq 0.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# ppseq 0.1.2
+
 # ppseq 0.1.1
 
 * Updating the included example data files

--- a/man/calibrate_thresholds.Rd
+++ b/man/calibrate_thresholds.Rd
@@ -14,6 +14,7 @@ calibrate_thresholds(
   ppp_threshold,
   direction = "greater",
   delta = NULL,
+  monitoring = "futility",
   prior = c(0.5, 0.5),
   S = 5000,
   nsim = 1000
@@ -55,6 +56,9 @@ if interest is in p(p1 < p0) for two-sample case. For one-sample case,
 
 \item{delta}{clinically meaningful difference between groups.
 Typically 0 for the two-sample case. NULL for the one-sample case (default).}
+
+\item{monitoring}{the type of interim monitoring to be perfomed. One of
+"futility" or "efficacy". Default is "futility".}
 
 \item{prior}{hyperparameters of prior beta distribution.
 Beta(0.5, 0.5) is default}

--- a/man/eval_thresh.Rd
+++ b/man/eval_thresh.Rd
@@ -13,6 +13,7 @@ eval_thresh(
   N,
   direction = "greater",
   delta = NULL,
+  monitoring = "futility",
   prior = c(0.5, 0.5),
   S = 5000
 )
@@ -39,6 +40,9 @@ if interest is in P(p1 < p0) for two-sample case. For one-sample case,
 \item{delta}{clinically meaningful difference between groups.
 Typically 0 for the two-sample case. NULL for the one-sample case (default).}
 
+\item{monitoring}{the type of interim monitoring to be perfomed. One of
+"futility" or "efficacy". Default is "futility".}
+
 \item{prior}{hyperparameters of prior beta distribution.
 Beta(0.5, 0.5) is default}
 
@@ -52,7 +56,7 @@ predictive probability generated from calc_predictive(), and an indicator
 for whether the trial was positive or not at the end
 }
 \description{
-Helper function for calibrate_thresholds() function that evaluates
-a single combination of a pp_threshold and a ppp_threshold for a single
-dataset
+Helper function for calibrate_thresholds() function that
+evaluates a single combination of a pp_threshold and a ppp_threshold for a
+single dataset
 }


### PR DESCRIPTION
Creates an option for efficacy monitoring in `calibrate_thresholds()` in addition to the default futility monitoring. With efficacy monitoring, the trial would stop early in the posterior predictive probability was greater than a pre-specified threshold, indicating that the trial had a high probability of success at full enrollment.

Closes #3 