### PR TITLE
updating calc_decision_rules when direction="less"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ppseq
 Title: Design Clinical Trials using Sequential Predictive Probability Monitoring
-Version: 0.2.3
+Version: 0.2.4
 Authors@R: 
   c(person(given = "Emily C.",
           family = "Zabor",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# ppseq 0.2.4
+
 # ppseq 0.2.3
 
 * added R Journal citation

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ppseq 0.2.4
 
+* fixed issue with `calc_decision_rules()` when `direction="less"` (Closed Issue #26)
+
 # ppseq 0.2.3
 
 * added R Journal citation

--- a/R/calc_decision_rules.R
+++ b/R/calc_decision_rules.R
@@ -103,34 +103,69 @@ calc_decision_rules <- function(n, N, theta, ppp, p0,
         ppp = NA_real_
       )
     
-    
-    ystart1 <- 0
-    ns <- paste0(c(res[[1, "n0"]], res[[1, "n1"]]),collapse=",")
-    for(i in 1:nrow(res)) {
-      pred <- 0
-      if( paste0(c(res[[i, "n0"]], res[[i, "n1"]]),collapse=",")!=ns ){
-       ns <- paste0(c(res[[i, "n0"]], res[[i, "n1"]]),collapse=",")
-       ystart1 <- 0
-      }      
-      for (j in ystart1:res[[i, "n1"]]) {
-        pred <- calc_predictive(
-          y = c(res[[i, "r0"]], j),
-          n = c(res[[i, "n0"]], res[[i, "n1"]]),
-          direction = direction,
-          p0 = p0,
-          delta = delta,
-          prior = prior,
-          S = S,
-          N = N,
-          theta = theta
-        )
-        if(pred > ppp) break else {
-          ystart1 <- ifelse(j > 0, j - 1, j)
-          
-          res[i, "r1"] <- j
-          res[i, "ppp"] <- pred
+    if(direction == "greater") {
+      
+      ystart1 <- 0
+      ns <- paste0(c(res[[1, "n0"]], res[[1, "n1"]]),collapse=",")
+      for(i in 1:nrow(res)) {
+        pred <- 0
+        if( paste0(c(res[[i, "n0"]], res[[i, "n1"]]),collapse=",")!=ns ){
+          ns <- paste0(c(res[[i, "n0"]], res[[i, "n1"]]),collapse=",")
+          ystart1 <- 0
+        }      
+        for (j in ystart1:res[[i, "n1"]]) {
+          pred <- calc_predictive(
+            y = c(res[[i, "r0"]], j),
+            n = c(res[[i, "n0"]], res[[i, "n1"]]),
+            direction = direction,
+            p0 = p0,
+            delta = delta,
+            prior = prior,
+            S = S,
+            N = N,
+            theta = theta
+          )
+          if(pred > ppp) break else {
+            ystart1 <- ifelse(j > 0, j - 1, j)
+            
+            res[i, "r1"] <- j
+            res[i, "ppp"] <- pred
+          }
         }
       }
+      
+    } else if(direction == "less") {
+      
+      ystart1 <- 0
+      ns <- paste0(c(res[[1, "n0"]], res[[1, "n1"]]),collapse=",")
+      for(i in 1:nrow(res)) {
+        pred <- 0
+        if( paste0(c(res[[i, "n0"]], res[[i, "n1"]]),collapse=",")!=ns ){
+          ns <- paste0(c(res[[i, "n0"]], res[[i, "n1"]]),collapse=",")
+          ystart1 <- 0
+        }      
+        for (j in ystart1:res[[i, "n1"]]) {
+          pred <- calc_predictive(
+            y = c(res[[i, "r0"]], j),
+            n = c(res[[i, "n0"]], res[[i, "n1"]]),
+            direction = direction,
+            p0 = p0,
+            delta = delta,
+            prior = prior,
+            S = S,
+            N = N,
+            theta = theta
+          )
+          if(pred < ppp) {
+            ystart1 <- ifelse(j > 0, j - 1, j)
+            
+            res[i, "r1"] <- j
+            res[i, "ppp"] <- pred
+            break
+          }
+        }
+      }
+      
     }
     
   } else if(length(N) == 1) {
@@ -171,7 +206,7 @@ calc_decision_rules <- function(n, N, theta, ppp, p0,
       ystart <- 0
       for (i in n) {
         pred <- 0
-        for(j in i:ystart) {
+        for(j in ystart:i) {
           pred <- calc_predictive(
             y = j,
             n = i,
@@ -183,9 +218,10 @@ calc_decision_rules <- function(n, N, theta, ppp, p0,
             N = N,
             theta = theta
           )
-          if(pred > ppp) break else{
+          if(pred < ppp) {
             res[i == n, 2] <- j
             res[i == n, 3] <- pred
+            break
           }
         }
         ystart <- ifelse(j > 0, j - 1, j)


### PR DESCRIPTION
Fixes a bug in calc_decision_rules() that was outputing an incorrect decision table when direction="less". 


Closes issue #26 


--------------------------------------------------------------------------------

How-to Checklist:

- [x] Create an issue in GitHub
- [x] Use GitHub desktop to create a new branch
- [x] Open `ppseq` R project and make sure it is on the right branch for the issue
- [x] Make changes to code
- [x] Run R CMD CHECK and fix any warnings or errors
- [ ] Run `pkgdown::build_site()`
- [x] Commit changes to the right branch for the issue
- [x] Use GitHub desktop to publish the new branch to GitHub
- [x] Use GitHub desktop to create a pull request associated with the new branch
- [x] On GitHub, add detailed comments to the pull request. Make sure to mention the # of the GitHub issue using keywords to close the issue automatically once the PR is merged (e.g. "Closes #1112")
- [x] Increment the version number using `usethis::use_version(which = "dev")` (or a different argument to which, if appropriate) 
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# ppseq (development version)`". If there is an issue associated with the pull request, reference it here.
- [x] Commit to the right branch for the issue and push to GitHub
- [x] Merge the PR using "Squash and merge" once all checks have passed
- [x] Delete both the local and remote branches
